### PR TITLE
[BOJ] 임태호 / 순.조.부

### DIFF
--- a/임태호/임태호[BFS,DFS]/[BOJ] 특정 거리의 도시 찾기_18352_실버2.java
+++ b/임태호/임태호[BFS,DFS]/[BOJ] 특정 거리의 도시 찾기_18352_실버2.java
@@ -1,0 +1,64 @@
+import java.util.*;
+import java.io.*;
+class Main {
+    public static class Road implements Comparable<Road> {
+        int end;
+        int cost;
+        public Road(int end, int cost) {
+            this.end = end;
+            this.cost = cost;
+        }
+        @Override
+        public int compareTo(Road o){
+            return this.cost > o.cost ? 1 : this.cost < o.cost ? -1 : this.end - o.end;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int n = readInt();
+        int m = readInt();
+        int k = readInt();
+        int x = readInt();
+        ArrayList<ArrayList<Integer>> map = new ArrayList<>();
+        for(int i =0; i<n; i++){
+            map.add(new ArrayList<>());
+        }
+        for(int i = 0; i < m; i++){
+            int start = readInt();
+            int end = readInt();
+            map.get(start-1).add(end-1);
+        }
+        PriorityQueue<Road> pq = new PriorityQueue<>();
+        boolean[] v = new boolean[n];
+        v[x-1] = true;
+        for(int i = 0; i < map.get(x-1).size(); i++){
+            pq.offer(new Road(map.get(x-1).get(i), 1));
+        }
+
+        while(pq.size() > 0){
+            Road now = pq.poll();
+            int end = now.end;
+            if(v[end]) continue;
+            v[end] = true;
+            int cost = now.cost;
+            if(cost > k) break;
+            if(cost == k) sb.append(end+1).append("\n");
+
+            for(int i = 0; i< map.get(end).size(); i++){
+                if(v[map.get(end).get(i)]) continue;
+                pq.offer(new Road(map.get(end).get(i), cost+1));
+            }
+        }
+        System.out.println(sb.length() == 0 ? -1 : sb);
+    }
+    public static int readInt() throws IOException {
+        int val;
+        int total = 0;
+        while((val = System.in.read()) > 32){
+            total= total*10 + val- '0';
+        }
+        return total;
+    }
+}

--- a/임태호/임태호[순,조,부]/[BOJ] ⚾_17281_골드4.java
+++ b/임태호/임태호[순,조,부]/[BOJ] ⚾_17281_골드4.java
@@ -1,0 +1,77 @@
+import java.util.*;
+import java.io.*;
+class Main {
+    //54,432,000
+    static int[] sel;
+    static boolean[] v;
+    static int[][] bat;
+    static int max = 0;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int n = readInt();
+        bat = new int[n][9];
+        for(int i = 0; i < n; i++){
+            for(int j = 0; j < 9; j++){
+                bat[i][j] = readInt();
+            }
+        }
+        sel = new int[9];
+        sel[3] = 0;
+        v = new boolean[9];
+        v[0] = true;
+        permutation(0);
+        System.out.println(max);
+
+    }
+    public static void permutation(int index){
+        if(index == 9){
+            calculate();
+            return;
+        }
+        if(index == 3){
+            permutation(index+1);
+            return;
+        }
+        for(int i = 0; i < 9; i++){
+            if(v[i]) continue;
+            v[i] = true;
+            sel[index] = i;
+            permutation(index + 1);
+            v[i] = false;
+        }
+    }
+    public static void calculate(){
+        int score = 0;
+        int outCount = 0;
+        int index = 0;
+        int base = 0;
+        while(outCount != bat.length *3){
+            int now = bat[outCount/3][sel[index]];
+            if(now == 0){
+                if(++outCount % 3 == 0) base = 0;
+            }
+            else{
+                base <<= now; // 주자 이동
+                base = base | (1 << (now-1) ); // 출루
+                if(base >= 8){
+                    if( (base & (1 << 6)) > 0) score++;
+                    if( (base & (1 << 5)) > 0) score++;
+                    if( (base & (1 << 4)) > 0) score++;
+                    if( (base & (1 << 3)) > 0) score++;
+                    base &= 7;
+                }
+            }
+            index = ++index == 9 ? 0 : index;
+        }
+        max = Math.max(max, score);
+    }
+    public static int readInt() throws IOException {
+        int val;
+        int total = 0;
+        while((val = System.in.read()) > 32){
+            total= total*10 + val- '0';
+        }
+        return total;
+    }
+}

--- a/임태호/임태호[순,조,부]/[BOJ] 부분수열의 합_1182_실버2.java
+++ b/임태호/임태호[순,조,부]/[BOJ] 부분수열의 합_1182_실버2.java
@@ -1,0 +1,30 @@
+import java.util.*;
+import java.io.*;
+class Main {
+    static int result;
+    static int m;
+    static int[] arr;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));;
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        arr = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for(int i =0; i<n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        result = 0;
+        powerset(0, 0);
+        System.out.println(m == 0 ? result -1 : result);
+    }
+    public static void powerset(int index, int sum){
+        if(index == arr.length){
+            if(sum == m) result++;
+            return;
+        }
+        powerset(index+1, sum+arr[index]);
+        powerset(index+1, sum);
+    }
+}

--- a/임태호/임태호[순,조,부]/[BOJ] 차이를 최대로_10819_실버2.java
+++ b/임태호/임태호[순,조,부]/[BOJ] 차이를 최대로_10819_실버2.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    static int[] arr;
+    static int n;
+    static int[] sel;
+    static boolean[] v;
+    static int max;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        arr = new int[n];
+        v = new boolean[n];
+        sel = new int[n];
+        max = 0;
+        for(int i = 0; i < n; i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        permutation(0);
+        System.out.println(max);
+    }
+    public static void permutation(int index){
+        if(index == n){
+            calculate();
+            return;
+        }
+        for(int i = 0; i < n ; i++){
+            if(v[i]) continue;
+            v[i] = true;
+            sel[index] = arr[i];
+            permutation(index+1);
+            v[i] = false;
+        }
+    }
+    public static void calculate(){
+        int sum = 0;
+        for(int i = 0; i < n-1; i++){
+            sum += Math.abs(sel[i] - sel[i+1]);
+        }
+        max = Math.max(sum,max);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 특정 거리의 도시 찾기_18352_실버2
-   플랫폼: [BOJ]
-   문제 분석: 
    - 1번부터 N 번까지의 도시와 M개의 **단 방향 도로**가 존재하고 모든 도로의 거리는 1입니다. (2 <= N <= 300,000 , 1 <= M <= 1,000,000)
    - 시작 점의 도시를 X(1 <= X <= N)가 주어졌을 때
    - 도달할 수 있는 모든 도시 중에서, 최단 거리가 정확히 K인 모든 도시들의 번호를 오름차순으로 출력하는 문제입니다.(1 <= K <= 300,000)

## 💡 아이디어 & 접근 방식

1. 이 문제는 그래프 최단 거리 탐색으로 방향이 있는 그래프의 탐색 알고리즘을 활용해야 한다고 생각했습니다.
2. 그래프 최단 거리 탐색 문제는 플로이드 워셜, 다익스트라, BFS 등 여러 가지 있지만 저는 여기서 BFS를 선택했습니다.
3. 그 이유는 플로이드 워셜은 해당 범위의 최대 값에서 연산을 진행하기에 시간 초과가 발생할 수 있고, 나머지 2개는 제한 시간 내에 프로그램을 작동할 수 있을 것이라 생각했습니다.
4. 다익스트라는 노드의 모든 최단 거리를 찾고, 거리가 K인 집합을 찾을 수 있는 반면 BFS는 가장 가까운 거리부터 탐색을 한다면 K에 대한 집합을 연산 중간에 구할 수 있을 것이라 생각해서 BFS를 사용했습니다.
5. 여기서 BFS를 사용할 때 고려해야 할 요소는 **거리**, **노드 번호** 두 개이기에 Priority Queue를 활용하여 구현했습니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항

## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 부분 수열의 합_1182_실버2
-   플랫폼: [BOJ]
-   문제 분석: 
    - N개의 정수로 이루어진 수열이 있을 때, 크기가 양수인 부분 수열 중에서 그 수열의 원소를 다 더한 값이 S가 되는 경우를 구하는 프로그램을 작성하는 문제입니다. 

## 💡 아이디어 & 접근 방식

1. 부분 집합으로 나올 수 있는 모든 경우의 수는 ${2^{20} -1}$ 대략 1,000,000 가지 이기 때문에 실행 시간에는 아무 문제가 없을 것으로 생각하여 powerset 으로 접근했습니다.
2. 부분 집합으로 나오는 모든 원소의 합이 정수 S가 되었을 때 count를 늘려주었고 총 수를 출력했습니다.
3. 여기서 중요하다고 생각한 점은 문제에서 **크기가 양수인** 부분 수열 중에서 연산을 진행하라는 점이라고 생각합니다.
4. 부분 집합에서 나오는 경우는 공 집합도 포함되기 때문에 공 집합에 해당하는 합이 0일 때, 즉, S = 0 일 경우 count를 하나 빼고 출력하여 공 집합을 배제했습니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항

## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 차이를 최대로_10819_실버2
-   플랫폼: [BOJ]
-   문제 분석: 
    - N개의 정수로 이루어진 배열 A가 있습니다. ( 3 <= N <= 8 ), (-100 <= ${A{_i}}$ <= 100 )
    - 각 배열의 순서가 정해졌을 때 다음과 같은 연산이 진행됩니다.
    - |A[0] - A[1]| + |A[1] - A[2] | + … + |A[N-2] = A[N-1]|
    - 위 식의 최대 값을 구하는 프로그램을 작성하는 문제입니다.

## 💡 아이디어 & 접근 방식
1. 순서에 따라 답이 달라질 수 있으므로 순열을 활용했습니다.
2. 순열에 대한 경우를 int[] sel의 일차원 배열에 저장했고, 배열의 값이 정해지면 해당 연산을 진행했습니다.
3. 반복문을 0부터 시작하여 n-2까지 진행하여 배열의 인덱스 범위가 초과하지 않도록 설정한 후 연산을 진행했습니다.


## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항

## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: ⚾_17281_ 골드4
-   플랫폼: [BOJ]
-   문제 분석: 
    - N이닝 동안 야구를 진행합니다. ( 2 <= N <= 50 )
    - 공격 팀의 구성은 타자와 베이스에 있는 주자의 구성으로 나뉩니다.
    - 주자의 역할은 다음과 같습니다.
    1. 주자는 1, 2, 3루를 거쳐서홈에 도착하면 공격 팀이 1점을 득점합니다.
    2. 주자가 홈에 도착하지 못하고 1루, 2루, 3루 중 하나에 머무를 수 있습니다.
    - 타자가 공을 쳐서 얻을 수 있는 결과는
    1. 안타(1) : 타자와 모든 주자가 한 루씩 진루합니다.
    2. 2루타(2) : 타자와 모든 주자가 두 루씩 진루합니다.
    3. 3루타(3) : 타자와 모든 주자가 세 루씩 진루합니다.
    4. 아웃(0) : 모든 주자는 진루하지 못하고, 아웃 카운트가 하나 늘어납니다.
    - 한 이닝에 아웃 카운트가 3개가 되면 다음 이닝부터는 마지막으로 아웃된 선수의 다음 타순부터 시작합니다.
    - 감독님은 1번부터 9번까지 번호가 매겨져 있는 타자의 순서를 정하려고 합니다. **단, 1번 선수를 4번째 순서로 미리 고정**해놨습니다.
    - 감독님은 각 이닝에서 타자들이 어떤 결과를 낼 수 있는 지 미리 알고 있습니다.
    - 모든 이닝이 끝났을 때 최대 득점을 하는 타순을 구하고 그 때의 득점을 구하는 문제입니다.
    - 시간 제한은 1초, 메모리 제한은 512MB입니다.

## 💡 아이디어 & 접근 방식

1. 우선 이 문제의 요구 사항이 타자의 순서를 구해야 하기 때문에 순서의 모든 경우의 수를 탐색할 수 있는 순열 알고리즘을 사용해야 된다고 생각했습니다.
2. 고정된 1번 선수를 제외하고 나머지 선수 8명의 타순을 정하는 경우의 수는 40,320입니다.
3. 이닝 수는 최대 50까지 주어지고, 각 이닝이 가장 늦게 끝나는 순간은 타자 중 아웃의 경우를 가진 사람이 1명 뿐일 때 가장 늦게 끝납니다. 즉, 50(이닝) X 3(아웃) X 9(명) = 1350으로 총, 1350 번 타자가 타순에 들어섭니다.
4. 1번과 2번의 경우를 전부 곱할 시 54,432,000이 나오고, Java의 시간복잡도로 대략 0.5초가 나옵니다.
5. 여기서 연산을 해야 할 것이 하나 더 남았는데 바로 타자들이 안타 또는 홈런의 경우에서 주자들의 행동을 연산해야 합니다.
6. 만약에 일차원 배열로 각 주자들을 탐색해가며 연산을 진행했을 때 적어도 3번의 반복을 진행해야 하기 때문에 시간제한을 충족시키지 못할 것이라 생각했습니다.
7. 그래서 비트 마스킹을 사용하여 주자를 표현하였고, 최대 비트 수는 3루에 있던 주자가 홈런을 날렸을 때 이동할 수 있도록 7개의 비트로 구성했습니다.
8. 타자가 안타 또는 홈런을 쳤을 때 비트 쉬프트 연산을 진행하여 주자를 이동하였고 비트 곱 연산을 통해 타자도 출루시켰습니다.
9. 만약 주자가 4번째 비트부터 위치할 경우, 점수의 카운트를 늘리고, 1비트 ~ 3비트까지 비트 곱 연산을 통해서 4번째 비트부터의 값을 전부 초기화시켰습니다.
10. 반복이 끝났으면 Math.max() 연산을 통해 최대 값을 도출해냈습니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항
