### PR TITLE
임태호 / 다익스트라, 플로이드워셜

### DIFF
--- a/임태호/임태호[Dijkstra]/[BOJ]최단경로_1753_골드4.java
+++ b/임태호/임태호[Dijkstra]/[BOJ]최단경로_1753_골드4.java
@@ -1,0 +1,53 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int v = Integer.parseInt(st.nextToken());
+        int e = Integer.parseInt(st.nextToken());
+        int start = Integer.parseInt(br.readLine())-1;
+        ArrayList<int[]>[] arr = new ArrayList[v];
+        int[] d = new int[v];
+        boolean[] vis = new boolean[v];
+        Arrays.fill(d, 2_000_001);
+        for(int i = 0; i < v; i++){
+            arr[i] = new ArrayList<>();
+        }
+        d[start] = 0;
+        PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>(){
+            @Override
+            public int compare(int[] o1, int[] o2){
+                return Integer.compare(o1[1], o2[1]);
+            }
+        });
+        for(int i = 0; i < e; i++){
+            st = new StringTokenizer(br.readLine());
+            int f = Integer.parseInt(st.nextToken())-1;
+            int s = Integer.parseInt(st.nextToken())-1;
+            int w  = Integer.parseInt(st.nextToken());
+            arr[f].add(new int[]{s, w});
+            if(f == start){
+                pq.offer(new int[]{s, w});
+            }
+        }
+        vis[start] = true;
+        while(pq.size() > 0){
+            int[] cur = pq.poll();
+
+            if(vis[cur[0]]) continue;
+            vis[cur[0]] = true;
+            d[cur[0]] = cur[1];
+
+            for(int i = 0; i < arr[cur[0]].size(); i++){
+                int[] next = arr[cur[0]].get(i);
+                pq.offer(new int[]{next[0], cur[1] + next[1]});
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < v; i++){
+            sb.append(d[i] == 2_000_001 ? "INF" : d[i]).append("\n");
+        }
+        System.out.println(sb);
+    }
+}

--- a/임태호/임태호[Dijkstra]/[BOJ]해킹_10282_골드4.java
+++ b/임태호/임태호[Dijkstra]/[BOJ]해킹_10282_골드4.java
@@ -1,0 +1,55 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+        for(int tc = 1; tc <= T; tc++){
+            st = new StringTokenizer(br.readLine());
+            int N = Integer.parseInt(st.nextToken());
+            int D =  Integer.parseInt(st.nextToken());
+            int C = Integer.parseInt(st.nextToken())-1;
+            int[] dist = new int[N];
+            dist[C] = 0;
+
+            ArrayList<int[]>[] map = new ArrayList[N];
+            for(int i = 0; i < N; i++){
+                map[i] = new ArrayList<>();
+            }
+
+            for(int i = 0 ; i < D; i++){
+                st = new StringTokenizer(br.readLine());
+                int end =  Integer.parseInt(st.nextToken())-1;
+                int start = Integer.parseInt(st.nextToken())-1;
+                int time =  Integer.parseInt(st.nextToken());
+                map[start].add(new int[]{end,time});
+            }
+
+            PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>(){
+                @Override
+                public int compare(int[] o1, int[] o2){
+                    return Integer.compare(o1[1], o2[1]);
+                }
+            });
+
+            boolean[] visited = new boolean[N];
+            int time = 0;
+            int count = 0;
+            pq.offer(new int[]{C, 0});
+            while(!pq.isEmpty()){
+                int[] cur = pq.poll();
+                if(visited[cur[0]]) continue;
+                visited[cur[0]] = true;
+                time = cur[1];
+                count++;
+                for(int i = 0; i < map[cur[0]].size(); i++){
+                    pq.offer(new int[]{map[cur[0]].get(i)[0], cur[1]+map[cur[0]].get(i)[1]});
+                }
+            }
+            sb.append(count).append(" ").append(time).append("\n");
+        }
+        System.out.print(sb);
+    }
+}

--- a/임태호/임태호[Dijkstra]/[PGS]합승 택시 요금_Lv3.java
+++ b/임태호/임태호[Dijkstra]/[PGS]합승 택시 요금_Lv3.java
@@ -1,0 +1,51 @@
+import java.util.*;
+class Solution {
+    static ArrayList<int[]>[] map;
+    public int solution(int n, int s, int a, int b, int[][] fares) {
+        // 0 : 출발 지점에서 , 1 : A 지점에서, 2 : B 지점에서
+        map = new ArrayList[n];
+        for(int i = 0; i < n; i++){
+            map[i] = new ArrayList<>();
+        }
+        int[] point = {s-1, a-1, b-1};
+        for(int i = 0; i < fares.length; i++){
+            int n1 = fares[i][0]-1;
+            int n2 = fares[i][1]-1;
+            int weight = fares[i][2];
+            map[n1].add(new int[]{n2,weight});
+            map[n2].add(new int[]{n1,weight});
+        }
+        int[][] dist = new int[3][n];
+        for(int i = 0; i < 3; i++){
+            Arrays.fill(dist[i], Integer.MAX_VALUE);
+            dijkstra(dist, i, point);
+        }
+
+        int min = Integer.MAX_VALUE;
+        for(int i = 0; i < n; i++){
+            min = Math.min(min, dist[0][i] + dist[1][i] + dist[2][i]);
+        }
+        return min;
+    }
+    public void dijkstra(int[][] dist, int index, int[] point){
+        dist[index][point[index]] = 0;
+        PriorityQueue<int[]> pq = new PriorityQueue<>(new Comparator<int[]>(){
+            @Override
+            public int compare(int[] o1, int[] o2){
+                return Integer.compare(o1[1], o2[1]);
+            }
+        });
+        boolean[] visited = new boolean[dist[0].length];
+        pq.offer(new int[]{point[index], 0});
+        while(pq.size() > 0){
+            int[] cur = pq.poll();
+            if(visited[cur[0]]) continue;
+            visited[cur[0]] = true;
+            dist[index][cur[0]] = cur[1];
+
+            for(int i = 0; i < map[cur[0]].size(); i++){
+                pq.offer(new int[]{ map[cur[0]].get(i)[0],map[cur[0]].get(i)[1] + cur[1] });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 해킹_10282_gold4
-   플랫폼: [BOJ]
-   문제 분석: 
    - 컴퓨터들 사이에는 방향과 시간이 있는 의존성이 있어, 만약 b가 a에 의존하면 b가 감염되면 일정 시간이 지나 a도 감염됩니다.
    - 반대로 a가 b에 의존하지 않는다면 b가 감염되어도 a는 감염되지 않습니다.
    - 감염은 처음 해킹된 컴퓨터에서 출발해 의존 관계를 따라 차례로 전파되며, 역방향은 일어나지 않습니다.
    - 주어진 시작 컴퓨터와 모든 의존성 정보를 바탕으로 감염되는 컴퓨터 수와 마지막 컴퓨터가 감염될 때까지 걸리는 최소 시간을 구하면 됩니다. 

## 💡 아이디어 & 접근 방식

- 방향 그래프에서 최단 거리를 구하는 문제라고 생각했습니다.
- 시작점이 주어지고, 가중치(해킹 시간)이 노드마다 다르므로 다익스트라를 통해 해결할 수 있다고 생각했습니다.
- int[] 타입 1차원 배열을 선언하여 시작 노드로부터 최단 거리를 저장하도록 했습니다. 이 배열을 dist라고 하겠습니다.
- boolean[] 타입 1차원 배열을 선언하여 해당 최단 거리를 구했을 때 더 이상 불필요한 탐색을 하지 않도록 하였습니다. 이 배열을 visited라고 하겠습니다.
- Priority Queue를 선언하여 입력한 데이터에 가중치에 따라서 오름차순으로 정렬하도록 했습니다.
- 다익스트라 진행 방식은 다음과 같습니다.
    1. 처음에 Priority Queue에 시작 노드를 입력하고 해당 가중치를 0으로 설정합니다.
    2. Priority Queue에서 데이터를 하나 꺼내고 해당 노드에 대한 visited 처리를 true로 합니다.
    3. dist 배열에 대한 해당 노드의 값도 현재 가중치로 설정합니다.
    4. 시작 노드와 연결되어 있는 모든 노드를 **현재 가중치 + 연결된 노드의 가중치** 를 연산하여 입력합니다.
    5. b, c, d를 Priority Queue가 비워질 때까지 반복합니다.
    6. 단, 이미 방문된 노드라면 다음 탐색을 진행합니다. (처음 방문 되었을 때의 가중치가 최소 가중치이기 때문입니다.)
- 방문된 노드의 개수와, Priority Queue의 마지막 데이터의 시간을 출력하면 됩니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항

## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 합승 택시 요금_Lv3
-   플랫폼: [PGS]
-   문제 분석: 
    - 두 사람이 같은 출발지점에서 택시를 타고, 각각 다른 도착지점까지 가는 상황에서 최소 택시 요금을 구하는 문제입니다.
    - 지점은 1부터 n까지 번호가 매겨져 있으며, 지점 사이에는 양방향 이동이 가능한 간선과 그에 따른 요금이 주어집니다.
    - 두 사람은 출발지점에서 일정 구간을 합승할 수도 있고, 어느 시점에서든 나눠 타고 각자 목적지까지 이동할 수 있습니다.
    - 합승 구간과 분리 구간을 적절히 선택하여 전체 요금 합이 최소가 되도록 계산해야 합니다.
    - 만약 합승하지 않고 따로 이동하는 경우가 더 저렴하다면, 합승하지 않아도 됩니다.
    - 문제의 목표는 합승 여부와 경로를 고려했을 때 가능한 최소 총 택시 요금을 반환하는 것입니다.

## 💡 아이디어 & 접근 방식

- 양방향 그래프에서 그래프의 최소 거리를 구하는 문제입니다.
- 정점의 개수가 많지 않아서 플로이드로 충분히 풀 수 있는 문제이지만, 실제로 필요한 정점의 시작점은 s , a, b 3개이므로 다익스트라를 3번 돌리면 된다고 생각했습니다.
- 그래서 각 시작점에 대한 최소 거리를 저장하기 위해 int[][] 타입의 2차원 배열을 선언했습니다. 행은 0, 1, 2 3개로 각각 시작점이 s일 때, a일 때, b일 때를 나타냅니다. 열은 정점 번호로 시작점에서 정점까지의 거리를 값으로 가집니다.
- 다익스트라 알고리즘은 다음과 같습니다.
    1.  처음에 PriorityQueue에 시작 노드를 입력하고 해당 가중치를 0으로 설정합니다.
    2. PriorityQueue에서 데이터를 하나 꺼내고 해당 노드에 대한 visited 처리를 true로 합니다.
    3. dist 배열에 대한 해당 노드의 값도 현재 가중치로 설정합니다.
    4. 시작 노드와 연결되어 있는 모든 노드를 현재 가중치 + 연결된 노드의 가중치 를 연산하여 입력합니다.
    5. b , c, d의 방식을 PriorityQueue 가 비워질 때까지 반복합니다.
    6. 단, 이미 방문된 노드라면 다음 탐색을 진행합니다.(처음 방문되었을 때의 가중치가 최소 가중치이기 때문입니다.)
- 위 과정을 시작 점을 각각 s, a, b로 설정하여 3번 반복합니다.
- 1차원 반복문을 통해 중간 지점(환승 지점)을 설정하여 경로에 대한 모든 경우의 수를 탐색하고 이 중 최소 값을 찾습니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항

## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 최단 경로_1753_gold4
-   플랫폼: [BOJ]
-   문제 분석: 
    - 방향 그래프가 주어질 때 주어진 시작점에서 다른 모든 정점으로의 최단 경로를 구하는 프로그램을 작성하는 문제입니다.
    - 만약 경로가 없다면 "INF'를 출력하면 됩니다.

## 💡 아이디어 & 접근 방식

- 방향 그래프에서의 최단 거리 문제라고 생각했습니다.
- 시작 점이 주어지고, 가중치가 노드마다 다르므로 다익스트라를 통해 해결할 수 있다고 생각했습니다.
- int[] 타입 1차원 배열을 선언하여 시작 노드로부터 최단 거리를 저장하도록 했습니다. 이 배열을 d라고 하겠습니다.
- d 배열의 값을 2_000_001로 초기화합니다.
- boolean[] 타입 1차원 배열을 선언하여 해당 최단 거리를 구했을 때 더 이상 불필요한 탐색을 하지 않도록 하였습니다. 이 배열을 vis라고 하겠습니다.
- PriorityQueue 를 선언하여 입력한 데이터에 가중치에 따라서 오름차순으로 정렬하도록 했습니다.
- 다익스트라 진행 방식은 다음과 같습니다.
    1. 처음에 PriorityQueue에 시작 노드를 입력하고 해당 가중치를 0으로 설정합니다.
    2. PriorityQueue에서 데이터를 하나 꺼내고 해당 노드에 대한 vis 처리를 true로 합니다.
    3. d 배열에 대한 해당 노드의 값도 현재 가중치로 설정합니다.
    4. 시작 노드와 연결되어 있는 모든 노드를 현재 가중치 + 연결된 노드의 가중치 를 연산하여 입력합니다.
    5. b , c, d의 방식을 PriorityQueue 가 비워질 때까지 반복합니다.
    6. 단, 이미 방문된 노드라면 다음 탐색을 진행합니다.(처음 방문되었을 때의 가중치가 최소 가중치이기 때문입니다.)
- 반복문을 통해 d 배열을 탐색하면서 값이 있으면 최소 거리를 출력하고 2_000_001 이라면 “INF”를 출력합니다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항


