### PR TITLE
Lhb

### DIFF
--- a/이현빈/이현빈[dp]/[BOJ] 어? 금지_30621_골드3.java
+++ b/이현빈/이현빈[dp]/[BOJ] 어? 금지_30621_골드3.java
@@ -1,0 +1,72 @@
+import java.io.*;
+import java.util.*;
+
+public class Main
+{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    static int N;
+    static long[] timeArr, compareArr, costArr;
+    static long[] dp;
+
+    public static void main(String[] args) throws IOException
+    {
+        N = Integer.parseInt(br.readLine());
+
+        // t
+        timeArr = new long[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++)
+            timeArr[i] = Long.parseLong(st.nextToken());
+
+        // b
+        compareArr = new long[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++)
+            compareArr[i] = Long.parseLong(st.nextToken());
+
+        // c
+        costArr = new long[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++)
+            costArr[i] = Long.parseLong(st.nextToken());
+
+        dp = new long[N + 1];
+
+        for (int i = 1; i <= N; i++)
+        {
+            dp[i] = dp[i - 1];
+
+            long threshold = timeArr[i - 1] - compareArr[i - 1];
+
+            int idx = binarySearch(threshold);
+
+            dp[i] = Math.max(dp[i], dp[idx] + costArr[i - 1]);
+        }
+
+        System.out.println(dp[N]);
+    }
+
+    static int binarySearch(long threshold)
+    {
+        int left = 0;
+        int right = N - 1;
+        int result = 0;
+
+        while (left <= right)
+        {
+            int mid = (left + right) / 2;
+
+            if (timeArr[mid] < threshold)
+            {
+                result = mid + 1;
+                left = mid + 1;
+            }
+            else
+                right = mid - 1;
+        }
+
+        return result;
+    }
+}

--- a/이현빈/이현빈[구현]/[BOJ] 마법사 상어와 파이어볼_20056_골드4.java
+++ b/이현빈/이현빈[구현]/[BOJ] 마법사 상어와 파이어볼_20056_골드4.java
@@ -1,0 +1,172 @@
+import java.io.*;
+import java.util.*;
+
+public class Main
+{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    static int N, M, K, sum;
+
+    static int[] fdx = {-1, -1, 0, 1, 1, 1, 0, -1};
+    static int[] fdy = {0, 1, 1, 1, 0, -1, -1, -1};
+
+    static class FireBall
+    {
+        int r, c, m, s, d;
+        boolean isUse;
+
+        public FireBall(int r, int c, int m, int s, int d)
+        {
+            this.r = r;
+            this.c = c;
+            this.m = m;
+            this.s = s;
+            this.d = d;
+            isUse = true;
+        }
+
+        public void Move()
+        {
+            if(!isUse) return;
+
+            r = (r + fdx[d] * (s % N) + N) % N;
+            c = (c + fdy[d] * (s % N) + N) % N;
+        }
+    }
+
+    static List<FireBall> fireballList;
+    static List<FireBall>[][] map;
+
+    public static void main(String[] args) throws IOException
+    {
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        sum = 0;
+
+        map = new ArrayList[N][N];
+        for (int i = 0; i < N; i++)
+            for (int j = 0; j < N; j++)
+                map[i][j] = new ArrayList<>();
+
+        // 파이어볼 생성
+        fireballList = new ArrayList<>();
+        for (int i = 0; i < M; i++)
+        {
+            st = new StringTokenizer(br.readLine());
+            int r = Integer.parseInt(st.nextToken()) - 1;
+            int c = Integer.parseInt(st.nextToken()) - 1;
+            int m = Integer.parseInt(st.nextToken());
+            int s = Integer.parseInt(st.nextToken());
+            int d = Integer.parseInt(st.nextToken());
+
+            FireBall fb = new FireBall(r,c,m,s,d);
+            fireballList.add(fb);
+            map[r][c].add(fb); // 이 자리에 fireball 이 하나 있다
+        }
+
+        for (int i = 0; i < K; i++)
+        {
+            // 맵 초기화
+            for (int x = 0; x < N; x++)
+                for (int y = 0; y < N; y++)
+                    map[x][y].clear();
+
+            // 파이어볼 이동
+            for(FireBall fb : fireballList)
+            {
+                fb.Move();
+                if(fb.isUse) map[fb.r][fb.c].add(fb);
+            }
+
+            // 파이어볼 합치기
+            CheckFireBall();
+
+            List<FireBall> newList = new ArrayList<>();
+            for (FireBall fb : fireballList)
+                if (fb.isUse) newList.add(fb);
+            fireballList = newList;
+        }
+
+        // 질량의 합
+        for(FireBall fb : fireballList)
+        {
+            if(fb.isUse)
+                sum += fb.m;
+        }
+
+        System.out.println(sum);
+    }
+
+    private static void CheckFireBall()
+    {
+        for (int i = 0; i < N; i++)
+        {
+            for (int j = 0; j < N; j++)
+            {
+                if(map[i][j].size() > 1) // 이 자리에 fireball 이 2개 이상인가?
+                {
+                    List<FireBall> tempList = map[i][j]; // 합쳐야될것들
+
+                    for(FireBall fb : tempList)
+                    {
+                        //fireballList.remove(fb); // 이제 여기에 없어야해
+                        fb.isUse = false; // 이제 안써요 이건
+                    }
+
+                    // 다음 질량, 속력 구하기
+                    int nm = 0;
+                    int ns = 0;
+                    for(FireBall fb : tempList)
+                    {
+                        nm += fb.m;
+                        ns += fb.s;
+                    }
+
+                    nm /= 5; // 질량
+                    if (nm == 0) continue;
+
+                    ns /= tempList.size(); // 속력
+
+                    boolean allEven = true;
+                    boolean allOdd = true;
+
+                    for (FireBall fb : tempList)
+                    {
+                        if (fb.d % 2 == 0) allOdd = false;
+                        else allEven = false;
+                    }
+
+                    if (allEven || allOdd) even(tempList, nm, ns);
+                    else odd(tempList, nm, ns);
+                }
+            }
+        }
+    }
+
+    private static void even(List<FireBall> tempList, int nm, int ns)
+    {
+        int d = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            FireBall newFb = new FireBall(tempList.get(0).r, tempList.get(0).c, nm, ns, d);
+            fireballList.add(newFb);
+            map[tempList.get(0).r][tempList.get(0).c].add(newFb);
+            d+=2;
+        }
+    }
+
+    private static void odd(List<FireBall> tempList, int nm, int ns)
+    {
+        int d = 1;
+        for (int i = 0; i < 4; i++)
+        {
+            FireBall newFb = new FireBall(tempList.get(0).r, tempList.get(0).c, nm, ns, d);
+            fireballList.add(newFb);
+            map[tempList.get(0).r][tempList.get(0).c].add(newFb);
+            d+=2;
+        }
+    }
+}

--- a/이현빈/이현빈[순.조.부]/[BOJ] 치킨배달_15686_골드5.java
+++ b/이현빈/이현빈[순.조.부]/[BOJ] 치킨배달_15686_골드5.java
@@ -1,0 +1,95 @@
+import java.io.*;
+import java.util.*;
+
+public class Main 
+{
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static StringTokenizer st;
+
+    static int N, M, myX, myY, chX, chY;
+    static int[][] mapArr;
+
+    static List<int[]> myHousePosList;
+    static List<int[]> chickenPosList;
+
+    static int MIN = Integer.MAX_VALUE;
+
+    public static void main(String[] args) throws IOException
+    {
+        st = new StringTokenizer(br.readLine());
+
+        // 초기화
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        mapArr = new int[N][N];
+        myHousePosList = new ArrayList<>();
+        chickenPosList = new ArrayList<>();
+
+        for(int i = 0; i < N; i++)
+        {
+            st = new StringTokenizer(br.readLine());
+
+            for (int j = 0; j < N; j++)
+            {
+                mapArr[i][j] = Integer.parseInt(st.nextToken());
+                if(mapArr[i][j] == 2)
+                    chickenPosList.add(new int[]{i, j});
+                else if(mapArr[i][j] == 1)
+                    myHousePosList.add(new int[]{i, j});
+            }
+        }
+
+        // M 개 만큼의 치킨집 좌표를 뽑아야함.
+        int[] arr = new int[chickenPosList.size()];
+        for(int i = 0; i < arr.length; i++)
+            arr[i] = i;
+
+        int[] sel = new int[M];
+        ChickenCombination(arr, sel, 0, 0);
+        System.out.println(MIN);
+    }
+
+    private static void ChickenCombination(int[] arr, int[] sel, int idx, int k)
+    {
+        // b
+        if(k == M)
+        {
+            int roadSum = 0;
+
+            for (int i = 0; i < myHousePosList.size(); i++)
+            {
+                myX = myHousePosList.get(i)[0];
+                myY = myHousePosList.get(i)[1];
+                int road = Integer.MAX_VALUE;
+
+                for (int j = 0; j < sel.length; j++)
+                {
+                    chX = chickenPosList.get(sel[j])[0];
+                    chY = chickenPosList.get(sel[j])[1];
+
+                    int temp = Math.abs(chX - myX) + Math.abs(chY - myY);
+
+                    if(temp < road)
+                        road = temp;
+                }
+
+                roadSum += road;
+
+                if(roadSum > MIN)
+                    return;
+            }
+
+            MIN = Math.min(MIN, roadSum);
+
+            return;
+        }
+
+        if(idx == chickenPosList.size())
+            return;
+
+        // i
+        sel[k] = arr[idx];
+        ChickenCombination(arr, sel, idx + 1, k + 1);
+        ChickenCombination(arr, sel, idx + 1, k);
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
[BOJ] 치킨 배달

## ✅ 문제 설명

-   문제 이름: 치킨 배달
-   플랫폼: BOJ
-   문제 분석: 

치킨집 중에서 최대 M개를 고르고, 나머지는 모두 폐업 시켜야한다.
가장 효율적으로 치킨집을 폐업 시키고, 치킨 거리의 최솟값을 뽑기.

## 💡 아이디어 & 접근 방식

처음엔 DFS로 접근하려고 했으나 M 개의 치킨집 좌표의 조합을 뽑는 과정에서

MyHousePos도 List 형태로 담아둔 다음에

조합을 뽑을 때 마다 MyHousePosList 에서 조합과의 거리를 계산한 최솟값을 갱신해주면 될 것 같다는 생각이 들었다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항
드라마틱한 시간을 기대했으나 생각보다 빠르지 않았음.
<img width="1154" height="117" alt="image" src="https://github.com/user-attachments/assets/0ccaadf8-7945-4fa3-9969-84d8cbd1c061" />

조합 for문안에 가지치기 전 → 176, 가지치기 후 172. 이 또한 시간이 엄청 빨라지진 않았음.
가지치는 실력으로 보아 조경원은 무리인듯하다.

## 📌 PR 제목
[BOJ] 어? 금지

## ✅ 문제 설명

-   문제 이름: 어? 금지
-   플랫폼: BOJ
-   문제 분석: 
N이 주어지고, N만큼 3개의 배열이 주어짐

t 배열은 내가 어? 를 외칠 수 있는 시간.

b 배열은 t(i) - b(i) 부터 t(i) 까지 어? 를 외친적이 없어야 한다는 제약조건

c 배열은 어? 를 외쳤을 때 혼란값을 저장할곳

최대 혼란을 주는 방법 구하기.

## 💡 아이디어 & 접근 방식

아무리 생각해도 완탐 말곤 떠오르지 않는데, 숫자들의 값이 심상치 않아서 시도 불가.
더군다나 모든 경우의 수를 비교하려면 순열을 뽑아야 한다고 생각했는데 N이 10만이다.
주어진 정보들로는 뾰족한 수가 떠오르지 않아서 알고리즘 분류를 확인 했는데 DP다.

- 첫번째 (실패) - 시간초과
    
    클로드와 함께 짠 DP 코드. 하지만, 실패
    
    매 초마다 threshold = timeArr[i-1] - 1 를 계산해서 진행해서 실패하였다.
    
    ```java
    for (int i = 1; i <= N; i++) <- 여기도 N번
    {
        for (int j = i - 1; j >= 0; j--)  <- 여기서도 최악의 경우 N번 반복
        {
            if (j == 0 || timeArr[j - 1] < threshold)
            {
                dp[i] = Math.max(dp[i], dp[j] + costArr[i - 1]);
                break;
            }
        }
    }
    ```
    
    N이 최대 10만인데, N^2 ⇒ 100억번의 연산 횟수로 인해 시간초과 발생
    

- 두번째 (성공) 이분탐색 추가
    
    ```
    static int binarySearch(long threshold)
    {
        int left = 0; // 여기가 시작점이 되는거고
        int right = N - 1; // 끝지점
        int result = 0; // dp[0] => 아무것도 안 외친 상태
    
        while (left <= right)
        {
            int mid = (left + right) / 2;  // 중간 지점 골라서
    
            if (timeArr[mid] < threshold)
            {
                // timeArr[mid]가 threshold보다 작음
                // → 더 큰 인덱스가 있을 수 있으니 오른쪽 탐색
                result = mid + 1;   // mid까지 사용 가능 (dp는 1-indexed)
                left = mid + 1;     // 오른쪽 절반 탐색
            }
            else
            {
                // timeArr[mid]가 threshold 이상
                // → 왼쪽에서 찾아야 함
                right = mid - 1;    // 왼쪽 절반 탐색
            }
        }
    
        return result;
    }
    ```
    
    ```
    timeArr = [1, 3, 5, 7, 9, 11, 13]  (인덱스 0~6)
    threshold = 8
    목표: 8보다 작은 가장 큰 값의 인덱스 찾기
    
    Step 1:
    left=0, right=6, mid=3
    timeArr[3]=7 < 8 ✓
    → result=4 (dp[4] 사용), left=4
    
    Step 2:
    left=4, right=6, mid=5
    timeArr[5]=11 >= 8 ✗
    → right=4
    
    Step 3:
    left=4, right=4, mid=4
    timeArr[4]=9 >= 8 ✗
    → right=3
    
    Step 4:
    left=4, right=3 → left > right
    종료!
    
    최종 result = 4
    → dp[4]를 사용 (인덱스 0,1,2,3까지 고려한 상태)
    ```
    위와 같이 진행된다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 스스로 해결

## 📝 특이사항
솔직히 말하면 내 코드에 대해서 이해도가 그리 높지 않다. 그래서 질문이 와도 양질의 답변을 못하지 않을까 싶다.
<img width="1172" height="115" alt="image" src="https://github.com/user-attachments/assets/7de180d8-7cf6-46f0-a44e-8be1b8aa779e" />

## 📌 PR 제목
[BOJ] 마법사 상어와 파이어볼

## ✅ 문제 설명

-   문제 이름: 마법사 상어와 파이어볼
-   플랫폼: BOJ
-   문제 분석: 

파이어볼이 맵에 존재한다.

모든 파이어볼은 한꺼번에 이동해야 한다.

이동이 끝나고 같은 칸에 모여진 파이어볼은 문제의 조건에 따라 처리를 해야한다.

```
모든 파이어볼이 자신의 방향 di로 속력 si칸 만큼 이동한다.
이동하는 중에는 같은 칸에 여러 개의 파이어볼이 있을 수도 있다.
이동이 모두 끝난 뒤, 2개 이상의 파이어볼이 있는 칸에서는 다음과 같은 일이 일어난다.
같은 칸에 있는 파이어볼은 모두 하나로 합쳐진다.
파이어볼은 4개의 파이어볼로 나누어진다.
나누어진 파이어볼의 질량, 속력, 방향은 다음과 같다.
질량은 ⌊(합쳐진 파이어볼 질량의 합)/5⌋이다.
속력은 ⌊(합쳐진 파이어볼 속력의 합)/(합쳐진 파이어볼의 개수)⌋이다.
합쳐지는 파이어볼의 방향이 모두 홀수이거나 모두 짝수이면, 방향은 0, 2, 4, 6이 되고, 그렇지 않으면 1, 3, 5, 7이 된다.
질량이 0인 파이어볼은 소멸되어 없어진다.
```

K만큼 이동 했을 때 맵에 남아있는 파이어볼에 질량의 합을 구하기

## 💡 아이디어 & 접근 방식

- 첫번째 (실패) - 시간초과
    그냥 구현했다. 근데 시간초과가 났다. 시간초과가 난 이유가 아마 리스트에 사용하지 않는 fireball이 남아 있어서 이 만큼의 루프가 또 도니까 그럴거라고 생각했다.
    
    fireball을 remove 하지 않고 isUse 라는 boolean 변수로 관리 한 이유는 remove 하는 도중에 자꾸
    
    ConcurrentModificationException 가 발생했다. 마땅히 해결 방법이 떠오르지 않고, 예전에 SWEA에서 문제 풀 때도 이렇게 관리한적이 있어서 그때와 똑같은 구조로 구성했다.
    

- 두번째 (실패) - 시간초과
    남아있는 리스트에서 사용하지 않는 파이어볼을 빼고 사용하는 애들로만 새로운 리스트를 만들어서 사용했다. 근데도 시간초과가 발생..
    
    솔직히 이제 이 문제에 내 시간을 쏟고 싶지 않다. 예제는 모두 맞는데 시간초과가 나는거라면 디버깅이 너무 어렵다..
    

- 세번째 (성공) - claude 사용
    static List<FireBall> fireballList;
    static List<FireBall>[][] map;
    
    이렇게 2개를 만들어서 진행했다.
    
    fireballList는 fireball 이 들어있는 list로
    
    map 은 그 r, c 위치에 fireball 이 몇개 있는지 체크하기 위함이다.
    
    초기엔 map 을 int로 구성해서 r,c 위치에 파이어볼이 몇개 있는지 알아냈으나.. 이렇게 했을 때 합쳐야 하는 파이어볼을 매번 전체 list를 탐색해서 찾아야 했음.
    
    그러지 말고 map에 fireball 을 담아두면 전체 리스트를 탐색해서 찾지 않아도 되기 때문에 시간이 줄어듦.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [ ] 스스로 해결

## 📝 특이사항

<img width="1233" height="195" alt="image" src="https://github.com/user-attachments/assets/1a84d19a-b0db-443a-8560-77d82bff36bc" />
