### PR TITLE
임태호 / Free Subject

### DIFF
--- a/임태호/임태호[Dynamic_Programming]/[BOJ]마라톤 2_10653_골드3.java
+++ b/임태호/임태호[Dynamic_Programming]/[BOJ]마라톤 2_10653_골드3.java
@@ -1,0 +1,48 @@
+import java.io.*;
+import java.util.*;
+public class Main {
+    public static void main(String[] args)throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        int[] pointX = new int[N];
+        int[] pointY = new int[N];
+
+        for(int i = 0; i < N; i++){
+            st= new StringTokenizer(br.readLine());
+            pointX[i]= Integer.parseInt(st.nextToken());
+            pointY[i] =Integer.parseInt(st.nextToken());
+        }
+        int[][] dist = new int[N][N];
+        for(int i = 0; i < N; i++){
+            for(int j = i+1; j < N; j++){
+                dist[i][j] = Math.abs(pointX[j]-pointX[i]) + Math.abs(pointY[j] - pointY[i]);
+            }   
+        }
+
+        int[][] dp = new int[K+1][N];
+        for(int i = 0; i <= K; i++){
+            Arrays.fill(dp[i], 123456789);
+        }        
+        dp[0][0] = 0;
+
+        
+        for(int i = 0; i <= K; i++){
+            for(int j = 1; j < N; j++){
+                dp[i][j] = dp[i][j-1] + dist[j-1][j];
+                for(int k = 0; k < j; k++){
+                    if(i-(j-k-1) >= 0) dp[i][j] = Math.min(dp[i][j] , dp[i-(j-k-1)][k] + dist[k][j]);
+                }
+            }
+        }
+        
+        int min = 123456789;
+        for(int i = 0; i <= K; i++){
+            min = Math.min(dp[i][N-1] , min);
+        }
+        System.out.println(min);
+
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

## ✅ 문제 설명

-   문제 이름: 마라톤 2_10653
-   플랫폼: [BOJ]
-   문제 분석: 
- 마라톤 코스는 1번부터 N번까지 순서대로 방문해야 하는 N개의 체크포인트로 구성된다.
- 참가자인 젖소 박승원은 1번과 N번을 제외하고 중간의 체크포인트 중 최대 K개를 건너뛸 수 있다.
- 각 체크포인트 사이의 거리는 맨해튼 거리(|x1−x2| + |y1−y2|)로 계산된다.
- 승원이 건너뛰기를 활용해 이동할 때, 전체 이동 거리의 최솟값을 구하는 것이 문제의 목표다.

## 💡 아이디어 & 접근 방식

- 우선 여기서 중요한 것은 최대 K개를 건너 뛰는 방법이고 그게 연속적이든 연속적이지 않아도 된다는 점이다. 예를 들어 1→ 5로 가는 경우중에 2, 3, 4 를 건너뛰거나, 2,3을 건너뛸 수 있다.
- 그래서 무조건 이전에 있는 모든 연산을 전부 비교해가면서 dp 연산을 진행할 수 밖에 없다.
- 점화식은 다음과 같다.
    - $dp_{i, j}$ = $Min(dp_{i, j} , dp_{i-(j-k-1)],k} + dist_{k, j}$  단 , i- (j-k-1) >= 0 ,
    - i : 건너 뛴 체크포인트의 개수, j : 현재 위치 , k : 현재 위치보다 이전 위치
    - $dp_{i,j}$ : 지금까지 i번 건너 뛰었을 때 j 위치에 도달했다면 그 때의 최소 비용
- i- (j-k-1) 은 4 → 5 로 갈 때 0개의 체크포인트를 건너 뛴다. 이때 나온 식이다.
- 최대 K 번 까지 건너 뛸 수 있으므로 0 ~ K 까지 건너뛰었을 때 N-1의 위치에 대한 값을 출력하면 된다.

## ✅ 해결 여부

-   [x] 예제 입력/출력 통과
-   [x] 모든 테스트 케이스 통과
-   [x] 스스로 해결

## 📝 특이사항
